### PR TITLE
fix deprecation warning message about Riiif::Engine.config.cache_duration_in_days

### DIFF
--- a/hyrax/config/initializers/riiif.rb
+++ b/hyrax/config/initializers/riiif.rb
@@ -23,4 +23,4 @@ Riiif::Image.authorization_service = Hyrax::IIIFAuthorizationService
 Riiif.not_found_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
 Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
 
-Riiif::Engine.config.cache_duration_in_days = 365
+Riiif::Engine.config.cache_duration = 365.days


### PR DESCRIPTION
This PR will fix https://github.com/antleaf/nims-mdr-development/issues/454 .