### PR TITLE
I459 metadata download hidden properties

### DIFF
--- a/hyrax/app/controllers/download_all_controller.rb
+++ b/hyrax/app/controllers/download_all_controller.rb
@@ -29,7 +29,7 @@ class DownloadAllController < Hyrax::DownloadsController
 
   # Override from DownloadBehavior
   def asset
-    @asset ||= Hyrax::WorkShowPresenter.new(
+    @asset ||= Hyrax::WorkPresenter.new(
       SolrDocument.new(work.to_solr),
       current_ability,
       request
@@ -55,7 +55,7 @@ class DownloadAllController < Hyrax::DownloadsController
   # Extend here to add other files to the zip
   def build_zip
     mk_zip_file_dir
-    # add_metadata
+    add_metadata
     add_files
     zip!
     cleanup
@@ -64,17 +64,11 @@ class DownloadAllController < Hyrax::DownloadsController
   # Add :ttl metadata
   # Change this method to write a different metadata format
   def add_metadata
-    if false
-      # Disabling this method for security reasons
-      File.write(
-        File.join(zip_file_path, 'metadata.ttl'),
-        # This presenter method #export_as_ttl doesn't work, possibly a bug
-        #   so grab the ttl directly from the work
-        # asset.export_as_ttl,
-        work.resource.dump(:ttl),
-        mode: 'wb'
-      )
-    end
+    File.write(
+      File.join(zip_file_path, 'metadata.ttl'),
+      asset.export_as_ttl,
+      mode: 'wb'
+    )
   end
 
   # Add all file_sets

--- a/hyrax/app/services/hyrax/graph_exporter.rb
+++ b/hyrax/app/services/hyrax/graph_exporter.rb
@@ -1,0 +1,94 @@
+module Hyrax
+  # Retrieves the graph for an object with the internal triples removed
+  # and the uris translated to external uris.
+  class GraphExporter
+    # @param [SolrDocument] solr_document idea here is that in the future, ActiveFedora may serialize the object as JSON+LD
+    # @param [ActionDispatch::Request] request the http request context
+    def initialize(solr_document, request)
+      @solr_document = solr_document
+      @request = request
+      @additional_resources = []
+      @visited_subresources = Set.new
+    end
+
+    attr_reader :solr_document, :request, :additional_resources
+
+    # @return [RDF::Graph]
+    def fetch
+      clean_graph_repository.find(solr_document.id).tap do |g|
+        additional_resources.each { |subgraph| g << subgraph }
+      end
+    rescue Ldp::NotFound
+      # this error is handled with a 404 page.
+      raise ActiveFedora::ObjectNotFoundError
+    end
+
+    private
+
+      def clean_graph_repository
+        Hydra::ContentNegotiation::CleanGraphRepository.new(connection, replacer)
+      end
+
+      def connection
+        @connection ||= CleanConnection.new(ActiveFedora.fedora.connection)
+      end
+
+      # This method is called once for each statement in the graph.
+      def replacer
+        lambda do |resource_id, graph|
+          return unless resource_id
+          url = ActiveFedora::Base.id_to_uri(resource_id)
+          klass = graph.query([:s, ActiveFedora::RDF::Fcrepo::Model.hasModel, :o]).first.object.to_s.constantize
+
+          # if the subject URL matches
+          if graph.query([RDF::URI(url), ActiveFedora::RDF::Fcrepo::Model.hasModel, nil]).first
+            subject_replacer(klass, resource_id)
+          elsif resource_id.start_with? solr_document.id
+            subresource_replacer(resource_id, klass)
+          else
+            object_replacer(resource_id, graph)
+          end
+        end
+      end
+
+      def subresource_replacer(resource_id, parent_klass)
+        return subject_replacer(parent_klass, resource_id) unless resource_id.include?('/')
+
+        parent_id, local = resource_id.split('/', 2)
+
+        if @visited_subresources.add?(resource_id)
+          additional_resources << ListSourceExporter.new(
+            resource_id,
+            request,
+            subject_replacer(parent_klass, parent_id)
+          ).fetch
+        end
+
+        parent = subject_replacer(parent_klass, parent_id)
+        "#{parent}/#{local}"
+      end
+
+      def subject_replacer(klass, resource_id, anchor = nil)
+        route_key = if Hyrax.config.curation_concerns.include?(klass)
+                      klass.model_name.singular_route_key
+                    else
+                      SolrDocument.model_name.singular_route_key
+                    end
+        routes = Rails.application.routes.url_helpers
+        builder = ActionDispatch::Routing::PolymorphicRoutes::HelperMethodBuilder
+        resource_id = RDF::URI(resource_id)
+        new_uri = RDF::URI(builder.polymorphic_method(routes, route_key, nil, :url, id: resource_id.path, host: hostname, anchor: anchor))
+        new_uri.fragment = resource_id.fragment
+        new_uri
+      end
+
+      def object_replacer(id, _graph)
+        id, anchor = id.split('/', 2)
+        Rails.application.routes.url_helpers.solr_document_url(id, host: hostname, anchor: anchor)
+      end
+
+      def hostname
+        request.host
+      end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/antleaf/nims-mdr-development/issues/459

This PR fixes two things
1. A fix in graph_exporter.rb to check for emply resource URLs. We can push this to Hyrax
    https://github.com/nims-dpfc/nims-hyrax/blob/6252fb69f296d96eff8f3ccbd86a283dbe3edaec/hyrax/app/services/hyrax/graph_exporter.rb#L39
2. Switched presenter from WorkShowPresenter to WorkPresenter in download_all_controller.rb, as it prepends FilteredGraph, which removes triples
    https://github.com/nims-dpfc/nims-hyrax/blob/6252fb69f296d96eff8f3ccbd86a283dbe3edaec/hyrax/app/controllers/download_all_controller.rb#L32

The ttl metadata from the dataset and the download use the same methods now. They are mostly similar, but still have differences. See attached files
[dataset_download_files_metadata.ttl.txt](https://github.com/nims-dpfc/nims-hyrax/files/6766731/dataset_download_files_metadata.ttl.txt)
[dataset_view_metadata_in_ttl_format.ttl.txt](https://github.com/nims-dpfc/nims-hyrax/files/6766739/dataset_view_metadata_in_ttl_format.ttl.txt)
