### PR TITLE
use ruby:2.6-buster

### DIFF
--- a/hyrax/Dockerfile
+++ b/hyrax/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6-buster
 
 # Setup build variables
 ARG RAILS_ENV


### PR DESCRIPTION
This PR will fix https://github.com/antleaf/nims-mdr-development/issues/475 .