### PR TITLE
Add workflow state filter to OAI

### DIFF
--- a/hyrax/config/initializers/oai_config.rb
+++ b/hyrax/config/initializers/oai_config.rb
@@ -10,5 +10,11 @@ OAI_CONFIG =
         document: {
             limit: 25,            # number of records returned with each request, default: 15
             supported_formats: %w(oai_dc jpcoar),
-        }
+        },
+        record_filters: [
+          # limit access to public records
+          'read_access_group_ssim: "public"',
+          # Get only those records in deposited workflow state
+          'workflow_state_name_ssim: "deposited"'
+        ]
     }


### PR DESCRIPTION
This fixes https://github.com/antleaf/nims-mdr-development/issues/469 for OAI

It is to make sure OAI will only show deposited records