### PR TITLE
update fluentd to 1.14

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,2 +1,2 @@
-FROM fluent/fluentd:v1.6-debian-1
+FROM fluent/fluentd:v1.14-debian-1
 USER fluent


### PR DESCRIPTION
Currently MDR is using fluentd 1.6, which was release 3 years ago.