### PR TITLE
specify GPL version explicitly

### DIFF
--- a/hyrax/config/authorities/rights_statements.yml
+++ b/hyrax/config/authorities/rights_statements.yml
@@ -45,7 +45,7 @@ terms:
       short_label: Apache-2.0
       human_url: https://www.apache.org/licenses/LICENSE-2.0
       active: true
-    - id: http://www.gnu.org/licenses/gpl.html
+    - id: https://www.gnu.org/licenses/gpl-3.0.html
       term: GNU General Public License v3.0
       active: true
     - id: https://opensource.org/licenses/MIT

--- a/hyrax/config/authorities/rights_statements.yml
+++ b/hyrax/config/authorities/rights_statements.yml
@@ -46,7 +46,7 @@ terms:
       human_url: https://www.apache.org/licenses/LICENSE-2.0
       active: true
     - id: http://www.gnu.org/licenses/gpl.html
-      term: GNU General Public License
+      term: GNU General Public License v3.0
       active: true
     - id: https://opensource.org/licenses/MIT
       term: MIT License


### PR DESCRIPTION
This PR is to update the label for GPL in the license list. The URL http://www.gnu.org/licenses/gpl.html points to GPL v3.0.