### PR TITLE
Move software form to method tab

### DIFF
--- a/hyrax/app/forms/hyrax/dataset_form.rb
+++ b/hyrax/app/forms/hyrax/dataset_form.rb
@@ -111,7 +111,8 @@ module Hyrax
         # :origin_system_provenance, # not using this
         :properties_addressed,
         :synthesis_and_processing,
-        :complex_feature
+        :complex_feature,
+        :complex_software
       ]
     end
 
@@ -120,7 +121,7 @@ module Hyrax
     end
 
     def specimen_tab_terms
-      [ :complex_chemical_composition, :complex_specimen_type, :complex_structural_feature, :complex_software ]
+      [ :complex_chemical_composition, :complex_specimen_type, :complex_structural_feature ]
     end
 
     NESTED_ASSOCIATIONS = [:complex_date, :complex_identifier, :complex_instrument,

--- a/hyrax/app/views/hyrax/datasets/_attribute_rows.html.erb
+++ b/hyrax/app/views/hyrax/datasets/_attribute_rows.html.erb
@@ -132,6 +132,7 @@
         <%= presenter.attribute_to_html(:properties_addressed, render_as: :faceted, label: t('ngdr.fields.properties_addressed'), html_dl: true) %>
         <%= presenter.attribute_to_html(:synthesis_and_processing, render_as: :faceted, label: t('ngdr.fields.synthesis_and_processing'), html_dl: true) %>
         <%= presenter.attribute_to_html(:complex_feature, render_as: :nested_feature, label: t('ngdr.fields.complex_feature'), html_dl: true) %>
+        <%= presenter.attribute_to_html(:complex_software, render_as: :nested_software, label: t('ngdr.fields.software'), html_dl: true) %>
       </div> <!-- panel body -->
     </div> <!-- Accordion body -->
   </div> <!-- Method accordion -->
@@ -167,7 +168,6 @@
         <%= presenter.attribute_to_html(:complex_specimen_type, render_as: :nested_specimen_type, label: t('ngdr.fields.complex_specimen_type'), html_dl: true) %>
         <%= presenter.attribute_to_html(:complex_chemical_composition, render_as: :nested_chemical_composition, label: t('ngdr.fields.complex_chemical_composition'), html_dl: true) %>
         <%= presenter.attribute_to_html(:complex_structural_feature, render_as: :nested_structural_feature, label: t('ngdr.fields.complex_structural_feature'), html_dl: true) %>
-        <%= presenter.attribute_to_html(:complex_software, render_as: :nested_software, label: t('ngdr.fields.software'), html_dl: true) %>
       </div> <!-- panel body -->
     </div> <!-- Accordion body -->
   </div> <!-- Specimen details accordion -->

--- a/hyrax/spec/forms/hyrax/dataset_form_spec.rb
+++ b/hyrax/spec/forms/hyrax/dataset_form_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Hyrax::DatasetForm do
       subject { form.method_tab_terms }
       it { is_expected.to include(:characterization_methods, :computational_methods, :properties_addressed, :synthesis_and_processing) }
       it { is_expected.to include(:complex_feature) }
+      it { is_expected.to include(:complex_software) }
     end
 
     describe '#instrument_tab_terms' do
@@ -41,7 +42,6 @@ RSpec.describe Hyrax::DatasetForm do
       it { is_expected.to include(:complex_specimen_type) }
       it { is_expected.to include(:complex_chemical_composition) }
       it { is_expected.to include(:complex_structural_feature) }
-      it { is_expected.to include(:complex_software) }
     end
   end
 


### PR DESCRIPTION
This PR is to move ComplexSoftware form from "Specimen" tab to "Method".