### PR TITLE
restore CrystallographicStructure form temporarily

### DIFF
--- a/hyrax/app/inputs/nested_specimen_type_input.rb
+++ b/hyrax/app/inputs/nested_specimen_type_input.rb
@@ -34,6 +34,25 @@ protected
     out << '  </div>'
     out << '</div>' # row
 
+    # --- complex_crystallographic_structure
+    field = :complex_crystallographic_structure
+    field_value = value.send(field)
+    if field_value.blank?
+      value.complex_crystallographic_structure.build
+      field_value = value.send(field)
+    end
+    nested_fields = NestedCrystallographicStructureInput.new(@builder, field, nil, :multi_value, {})
+    out << "<div class='inner-nested'>"
+    out << "<div class='form-group'>"
+    out << "  <label class='control-label optional' for='dataset_#{field.to_s}'>Crystallographic structure</label>"
+    out << nested_fields.nested_input({:class=>"form-control", :repeats => false}, field_value, parent_attribute)
+    out << "</div>"
+    # out << "  <button type='button' class='btn btn-link add'>"
+    # out << "    <span class='glyphicon glyphicon-plus'></span>"
+    # out << "    <span class='controls-add-text'>Add another crystallographic structure</span>"
+    # out << "  </button>"
+    out << "</div>" # row
+
     # --- description
     field = :description
     field_name = name_for(attribute_name, index, field, parent)


### PR DESCRIPTION
We are going to separate `CrystallographicStructure` from `ComplexSpecimenType` in the PR https://github.com/nims-dpfc/nims-hyrax/pull/489 , but I already [removed the CrystallographicStructure form from the Specimen tab](https://github.com/nims-dpfc/nims-hyrax/commit/4b5d26815eafa66eef2f41846bd10db8a00cc0fc#diff-0d5e63d201f1cc5032227fa332d286b0f6510d8231a3f36d3ec526696a697321) in the `develop` branch. This PR is to restore the CrystallographicStructure form in the Specimen tab temporarily.