### PR TITLE
Upgraded OAI gem to work with rails 5

### DIFF
--- a/hyrax/Gemfile
+++ b/hyrax/Gemfile
@@ -92,7 +92,7 @@ group :production do
 end
 
 gem 'willow_sword', git: 'https://github.com/CottageLabs/willow_sword.git', :branch => 'develop'
-gem 'blacklight_oai_provider', git: 'https://github.com/CottageLabs/blacklight_oai_provider.git', branch: 'master'
+gem 'blacklight_oai_provider', git: 'https://github.com/CottageLabs/blacklight_oai_provider.git', branch: 'oai_upgrade'
 
 group :test do
   gem 'simplecov', require: false

--- a/hyrax/Gemfile.lock
+++ b/hyrax/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/CottageLabs/blacklight_oai_provider.git
-  revision: 73d5f34315e313fb22084cfc52939d71e3c0728a
-  branch: master
+  revision: 1512a30a5e5ecab40ca016cf2ab4a23973383b30
+  branch: oai_upgrade
   specs:
     blacklight_oai_provider (1.4.1)
       blacklight (>= 6.1)
-      oai (~> 0.4.0)
-      rails (>= 4.2)
+      oai (~> 1.0)
+      rails (>= 5.2)
 
 GIT
   remote: https://github.com/CottageLabs/willow_sword.git
@@ -665,7 +665,7 @@ GEM
       racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
-    oai (0.4.0)
+    oai (1.1.0)
       builder (>= 3.1.0)
       faraday
       faraday_middleware


### PR DESCRIPTION
fixes https://github.com/antleaf/nims-mdr-development/issues/504. This fix is needed to upgrade ruby.

Once this is approved in test, we should merge the [blacklight_oai_provider oai_upgrade branch](https://github.com/CottageLabs/blacklight_oai_provider/tree/oai_upgrade) to master, before releasing to production.