### PR TITLE
restrict the version of faraday_middleware

### DIFF
--- a/hyrax/Gemfile
+++ b/hyrax/Gemfile
@@ -72,7 +72,7 @@ gem 'sidekiq', '~> 5.2.10'
 gem 'hydra-role-management'
 gem 'bootstrap-datepicker-rails'
 gem 'pg'
-gem 'faraday_middleware'
+gem 'faraday_middleware', '~> 0.14'
 gem 'devise_ldap_authenticatable'
 
 gem 'cancancan', '~> 1.17' # NB: locked to an older version because of hyrax > hydra-editor

--- a/hyrax/Gemfile.lock
+++ b/hyrax/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
       faraday
-    faraday_middleware (0.13.1)
+    faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
@@ -1023,7 +1023,7 @@ DEPENDENCIES
   exception_notification-rake (~> 0.3.1)
   factory_bot_rails
   faraday
-  faraday_middleware
+  faraday_middleware (~> 0.14)
   fcrepo_wrapper
   hydra-role-management
   hyrax (~> 2.9)


### PR DESCRIPTION
This PR will fix https://github.com/antleaf/nims-mdr-development/issues/596 .