### PR TITLE
Fix for striped bar not appearing

### DIFF
--- a/hyrax/app/assets/stylesheets/ngdr.scss
+++ b/hyrax/app/assets/stylesheets/ngdr.scss
@@ -151,3 +151,8 @@ div#announcement {
   visibility: hidden;
   display: none;
 }
+
+.progress {
+  background-color: #286090;
+  padding-left: 5px;
+}

--- a/hyrax/app/views/hyrax/base/_form_progress.html.erb
+++ b/hyrax/app/views/hyrax/base/_form_progress.html.erb
@@ -66,7 +66,7 @@
 
   <%# Provide immediate feedback after the form is submitted while the subsequent page is loading %>
   <div class="panel-footer hidden">
-    <div class="progress">
+    <div class="progress" style="background-color: #286090;">
       <div class="progress-bar progress-bar-striped progress-bar-complete active">
         <span id="form-feedback" aria-live="assertive">Saving your work. This may take a few moments</span>
       </div>


### PR DESCRIPTION
fixes https://github.com/antleaf/nims-mdr-development/issues/429

The background color for the progress bar comes from bootstrap. The application css is not being applied. The only way to override was to use inline style in [hyrax/app/views/hyrax/base/_form_progress.html.erb](https://github.com/nims-dpfc/nims-hyrax/pull/543/files#diff-82f879867f68a396bf6f2683123daa06bf3981a965af724116cc8297b47bd714R69)