### PR TITLE
Adding license desctription to complex rights

### DIFF
--- a/hyrax/app/forms/hyrax/dataset_form.rb
+++ b/hyrax/app/forms/hyrax/dataset_form.rb
@@ -30,6 +30,7 @@ module Hyrax
       :specimen_set_ordered, 
       :publisher, :date_published, 
       :rights_statement, :licensed_date,
+      :complex_rights,
       :complex_person, 
       :complex_contact_agent,
       :complex_source, :manuscript_type, 
@@ -91,7 +92,8 @@ module Hyrax
         :specimen_set_ordered, 
         :material_type,
         :publisher, :date_published, 
-        :rights_statement, :licensed_date, 
+        :rights_statement, :licensed_date,
+        :complex_rights,
         :complex_person, 
         :complex_contact_agent,
         :complex_source, :manuscript_type,
@@ -131,7 +133,7 @@ module Hyrax
     NESTED_ASSOCIATIONS = [:complex_date, :complex_identifier, :complex_instrument,
       :complex_organization, :complex_person, :complex_relation, :complex_event,
       :complex_funding_reference, :complex_contact_agent, :complex_chemical_composition,
-      :complex_crystallographic_structure,
+      :complex_crystallographic_structure, :complex_rights,
       :complex_structural_feature, :complex_software, :complex_feature,
       :complex_source, :complex_specimen_type, :complex_version, :custom_property].freeze
 
@@ -318,7 +320,8 @@ module Hyrax
        :_destroy,
        {
          date: [],
-         rights: []
+         rights: [],
+         license_description: []
        }
       ]
     end
@@ -475,6 +478,7 @@ module Hyrax
       permitted << :licensed_date
       permitted << { complex_identifier_attributes: permitted_identifier_params }
       permitted << { complex_instrument_attributes: permitted_instrument_params }
+      permitted << { complex_rights_attributes: permitted_rights_params }
       permitted << { complex_person_attributes: permitted_person_params }
       permitted << { complex_organization_attributes: permitted_organization_params }
       permitted << { complex_relation_attributes: permitted_relation_params }

--- a/hyrax/app/indexers/complex_field/rights_indexer.rb
+++ b/hyrax/app/indexers/complex_field/rights_indexer.rb
@@ -9,6 +9,7 @@ module ComplexField
     def index_rights(solr_doc)
       solr_doc[Solrizer.solr_name('complex_rights', :displayable)] = object.complex_rights.to_json
       solr_doc[Solrizer.solr_name('complex_rights', :facetable)] = object.complex_rights.map { |r| r.rights.reject(&:blank?).first }
+      solr_doc[Solrizer.solr_name('complex_rights_description', :searchable)] = object.complex_rights.map { |r| r.license_description.reject(&:blank?).first }
     end
 
     def self.rights_facet_fields
@@ -22,6 +23,7 @@ module ComplexField
       # solr fields that will be used for a search
       fields = []
       fields << Solrizer.solr_name('complex_rights', :facetable)
+      fields << Solrizer.solr_name('complex_rights_description', :searchable)
       fields
     end
 

--- a/hyrax/app/inputs/nested_rights_input.rb
+++ b/hyrax/app/inputs/nested_rights_input.rb
@@ -1,0 +1,77 @@
+class NestedRightsInput < NestedAttributesInput
+
+protected
+
+  def build_components(attribute_name, value, index, options, parent=@builder.object_name)
+    out = ''
+
+    # Inherit required for fields validated in nested attributes
+    required  = false
+    if object.required?(:complex_rights) and index == 0
+      required = true
+    end
+
+    # --- rights
+    rights_options = RightsService.new.select_all_options
+    field = :rights
+    field_name = name_for(attribute_name, index, field, parent)
+    field_id = id_for(attribute_name, index, field, parent)
+    field_value = value.send(field).first
+
+    out << "<div class='row'>"
+    out << "  <div class='col-md-3'>"
+    out << template.label_tag(field_name, field.to_s.humanize, required: required)
+    out << '  </div>'
+
+    out << "  <div class='col-md-9'>"
+    out << template.select_tag(field_name, template.options_for_select(rights_options, field_value),
+                               prompt: 'Select rights', label: '', class: 'select form-control', id: field_id, required: required)
+    out << '  </div>'
+    out << '</div>' # row
+
+    # --- date
+    field = :date
+    field_name = name_for(attribute_name, index, field, parent)
+    field_id = id_for(attribute_name, index, field, parent)
+    field_value = value.send(field).first
+
+    out << "<div class='row'>"
+    out << "  <div class='col-md-3'>"
+    out << template.label_tag(field_name, field.to_s.humanize, required: false)
+    out << '  </div>'
+
+    out << "  <div class='col-md-6'>"
+    out << @builder.text_field(field_name,
+        options.merge(value: field_value, name: field_name, id: field_id,
+            data: { provide: 'datepicker' }, required: false))
+    out << '  </div>'
+    out << '</div>' # row
+
+    # last row
+    out << "<div class='row'>"
+
+    # --- license_description
+    field = :license_description
+    field_name = name_for(attribute_name, index, field, parent)
+    field_id = id_for(attribute_name, index, field, parent)
+    field_value = value.send(field).first
+
+    out << "  <div class='col-md-3'>"
+    out << template.label_tag(field_name, field.to_s.humanize, required: false)
+    out << '  </div>'
+
+    out << "  <div class='col-md-6'>"
+    out << @builder.text_field(field_name,
+                               options.merge(value: field_value, name: field_name, id: field_id))
+    out << '  </div>'
+
+    # --- delete checkbox
+    field_label = 'Rights'
+    out << "  <div class='col-md-3'>"
+    out << destroy_widget(attribute_name, index, field_label, parent)
+    out << '  </div>'
+
+    out << '</div>' # last row
+    out
+  end
+end

--- a/hyrax/app/models/concerns/complex_rights.rb
+++ b/hyrax/app/models/concerns/complex_rights.rb
@@ -5,6 +5,7 @@ class ComplexRights < ActiveTriples::Resource
   property :date, predicate: ::RDF::Vocab::DISCO.startDate
   property :rights, predicate: ::RDF::Vocab::DC.rights
   property :label, predicate: ::RDF::Vocab::SKOS.prefLabel
+  property :license_description, predicate: ::RDF::Vocab::DC.description
 
   ## Necessary to get AT to create hash URIs.
   def initialize(uri, parent)

--- a/hyrax/app/renderers/nested_rights_attribute_renderer.rb
+++ b/hyrax/app/renderers/nested_rights_attribute_renderer.rb
@@ -11,6 +11,10 @@ class NestedRightsAttributeRenderer < NestedAttributeRenderer
       # start date
       val = v.fetch('date', [])
       each_html += get_row('Date', val[0]) unless val.blank?
+      # License description
+      val = v.fetch('license_description', [])
+      each_html += get_row('License description', val[0]) unless val.blank?
+      # Add it all
       html += get_inner_html(each_html)
     end
     html_out = get_ouput_html(html)

--- a/hyrax/app/views/hyrax/datasets/_attribute_rows.html.erb
+++ b/hyrax/app/views/hyrax/datasets/_attribute_rows.html.erb
@@ -58,6 +58,7 @@
           <%= presenter.attribute_to_html(:rights_statement, render_as: :mdr_rights_statement, html_dl: true) %>
           <%#= # presenter.attribute_to_html(:rights_notes, html_dl: true) %>
           <%= presenter.attribute_to_html(:licensed_date, label: t('ngdr.fields.licensed_date'), html_dl: true) %>
+          <%= presenter.attribute_to_html(:complex_rights, render_as: :nested_rights, label: t('ngdr.fields.complex_rights'), html_dl: true) %>
         <% end %>
 
         <% if can? :read_source, presenter.model_name.name.constantize %>

--- a/hyrax/spec/factories/dataset.rb
+++ b/hyrax/spec/factories/dataset.rb
@@ -494,6 +494,16 @@ FactoryBot.define do
       }
     end
 
+    trait :with_complex_rights do
+      complex_rights_attributes {
+        [{
+           rights: 'http://creativecommons.org/publicdomain/zero/1.0/',
+           date: '1978-10-28',
+           license_description: 'A customised rights statement'
+         }]
+      }
+    end
+
     trait :with_complex_version do
       complex_version_attributes {
         [{

--- a/hyrax/spec/forms/hyrax/dataset_form_spec.rb
+++ b/hyrax/spec/forms/hyrax/dataset_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hyrax::DatasetForm do
         :first_published_url,
         :title, :alternative_title, :resource_type, :data_origin, :description,
         :keyword_ordered, :specimen_set_ordered,
-        :material_type, :publisher, :date_published, :rights_statement,
+        :material_type, :publisher, :date_published, :rights_statement, :complex_rights,
         :licensed_date,
         :complex_person, :complex_contact_agent, :complex_source,
         :manuscript_type,
@@ -64,6 +64,7 @@ RSpec.describe Hyrax::DatasetForm do
         expect(described_class).to receive(:permitted_relation_params).at_least(:once).and_call_original
         expect(described_class).to receive(:permitted_specimen_type_params).at_least(:once).and_call_original
         expect(described_class).to receive(:permitted_version_params).at_least(:once).and_call_original
+        expect(described_class).to receive(:permitted_rights_params).at_least(:once).and_call_original
         expect(described_class).to receive(:permitted_event_params).at_least(:once).and_call_original
         expect(described_class).to receive(:permitted_source_params).at_least(:once).and_call_original
         expect(described_class).to receive(:permitted_custom_property_params).at_least(:once).and_call_original

--- a/hyrax/spec/models/concerns/complex_rights_spec.rb
+++ b/hyrax/spec/models/concerns/complex_rights_spec.rb
@@ -44,13 +44,15 @@ RSpec.describe ComplexRights do
       complex_rights_attributes: [{
         date: '1978-10-28',
         rights: 'https://creativecommons.org/publicdomain/zero/1.0/',
-        label: 'CC-0'
+        label: 'CC-0',
+        license_description: 'Some description for the rights'
       }]
     }
     expect(@obj.complex_rights.first).to be_kind_of ActiveTriples::Resource
     expect(@obj.complex_rights.first.date).to eq ['1978-10-28']
     expect(@obj.complex_rights.first.rights).to eq ['https://creativecommons.org/publicdomain/zero/1.0/']
     expect(@obj.complex_rights.first.label).to eq ['CC-0']
+    expect(@obj.complex_rights.first.license_description).to eq ['Some description for the rights']
   end
 
   describe 'when reject_if is a symbol' do
@@ -81,7 +83,8 @@ RSpec.describe ComplexRights do
       @obj.attributes = {
         complex_rights_attributes: [{
           date: '2018-01-01',
-          label: 'cc0'
+          label: 'cc0',
+          license_description: 'Some description for the rights'
         }]
       }
       expect(@obj.complex_rights).to be_empty


### PR DESCRIPTION
fixes https://github.com/antleaf/nims-mdr-development/issues/612

This PR is in draft because:

I have added the license description field to complex rights, but it doesn't seem to be used any more. I have enabled the field in the form, but not sure if that is what is required? Should we hide rights_statement and license date?

Should we add a simple field called license_description instead in the dataset model?