### PR TITLE
Solr 8 container

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -28,6 +28,12 @@ services:
     ports:
       - 8983:8983
 
+  solr8:
+    environment:
+      - OOM=script
+    ports:
+      - 8987:8983
+
   web:
     ports:
       - 3000:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 volumes:
   solr:
+  solr8:
   db:
   db-fcrepo:
   app:
@@ -53,6 +54,31 @@ services:
       - sh
       - "-c"
       - "precreate-core hydra-test /opt/solr/solr_conf; solr-precreate ${SOLR_CORE} /opt/solr/solr_conf"
+
+  solr8:
+    image: solr:8
+    expose:
+      - 8983
+    ports:
+      - 8987:8983
+    env_file:
+      - .env
+    environment:
+      - OOM=script
+    healthcheck:
+      test: ["CMD-SHELL", "wget -O /dev/null http://localhost:8987/solr/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      internal:
+    volumes:
+      - solr8:/var/solr
+      - ./hyrax/solr8/conf:/opt/solr/solr_conf
+    command:
+      - sh
+      - "-c"
+      - "precreate-core ${SOLR_TEST_CORE} /opt/solr/solr_conf; solr-precreate ${SOLR_CORE} /opt/solr/solr_conf"
 
   db: &db
     image: postgres:11-alpine
@@ -114,6 +140,7 @@ services:
     depends_on:
       - appdb
       - solr
+      - solr8
       - fcrepo
       - redis
     expose:
@@ -125,6 +152,7 @@ services:
     depends_on:
       - appdb
       - solr
+      - solr8
       - fcrepo
       - redis
 


### PR DESCRIPTION
fixes https://github.com/antleaf/nims-mdr-development/issues/620

To reindex all documents, 
* Modify the `SOLR_HOST=solr` in .env to `SOLR_HOST=solr8`
* Bring down the containers, build the container and bring up the containers
* In the browser, go to the ui for solr and solr 8. Kepp an eye on number of documents
* Login to the web container and reindex all documents. I ran the rake task `rake solr:reindex`
* After the reindex is done, log into the web interface to check everything looks fine
* Add a dcoument and check it is being indexed in the correct solr instance. Once we are happy with this, we can remove the old solr container